### PR TITLE
Fix prettier, ts and eslint warnings

### DIFF
--- a/packages/waku/src/lib/middleware/handler.ts
+++ b/packages/waku/src/lib/middleware/handler.ts
@@ -107,7 +107,8 @@ export const handler: Middleware = (options) => {
         )
       : await entriesPrd.loadModule(CLIENT_PREFIX + 'waku-minimal-client');
     (rsdwServer as any).default.setPreloadModule((id: string) =>
-      (globalThis as any).__WAKU_SERVER_IMPORT__(id))
+      (globalThis as any).__WAKU_SERVER_IMPORT__(id),
+    );
     ctx.unstable_modules = {
       rsdwServer,
       rdServer,

--- a/packages/waku/src/lib/plugins/vite-plugin-rsc-rsdw.ts
+++ b/packages/waku/src/lib/plugins/vite-plugin-rsc-rsdw.ts
@@ -1,6 +1,7 @@
 import type { Plugin } from 'vite';
 
-const patchRsdw = (code: string, type: 'SERVER' | 'CLIENT') => {
+// @ts-expect-error might not need this
+const _patchRsdw = (code: string, type: 'SERVER' | 'CLIENT') => {
   code = code.replace(
     /__webpack_(\w+)__/g,
     (_, p1) => `__WAKU_${type}_${p1.toUpperCase()}__`,
@@ -54,8 +55,9 @@ export function rscRsdwPlugin(): Plugin {
         return this.resolve(id, importer, options);
       }
     },
-    transform(code, id) {
-      if (1) return;
+    transform(_code, _id) {
+      return;
+      /* Moved
       const [file, opt] = id.split('?');
       if (
         ['commonjs-exports', 'commonjs-proxy', 'commonjs-entry'].includes(opt!)
@@ -86,6 +88,7 @@ export function rscRsdwPlugin(): Plugin {
       if (code.includes('function requireAsyncModule(id)')) {
         throw new Error('rscRsdwPlugin: Untransformed file: ' + file);
       }
+      */
     },
   };
 }

--- a/packages/waku/src/lib/renderers/html.ts
+++ b/packages/waku/src/lib/renderers/html.ts
@@ -182,11 +182,16 @@ export async function renderHtml(
   } = modules.rsdwClient as { default: typeof RSDWClientType };
 
   // previously normalized through clientBundlerConfig and serverConsumerManifest.moduleMap
-  const resolveClientEntryForPrd = (id: string, config: { basePath: string }) => {
+  const resolveClientEntryForPrd = (
+    id: string,
+    config: { basePath: string },
+  ) => {
     return config.basePath + id + '.js';
   };
   function normalizeModuleId(id: string) {
-    id = ctx.unstable_devServer ? ctx.unstable_devServer.resolveClientEntry(id) : resolveClientEntryForPrd(id, config);
+    id = ctx.unstable_devServer
+      ? ctx.unstable_devServer.resolveClientEntry(id)
+      : resolveClientEntryForPrd(id, config);
     if (ctx.unstable_devServer) {
       id = id.slice(config.basePath.length);
       if (id.startsWith('@id/')) {
@@ -196,14 +201,14 @@ export async function renderHtml(
       } else {
         id = filePathToFileURL(id);
       }
-      return id
+      return id;
     }
     // !isDev
     id = id.slice(config.basePath.length);
-    return id
+    return id;
   }
   (modules.rsdwClient as any).default.setPreloadModule((id: string) => {
-    return (globalThis as any).__WAKU_CLIENT_IMPORT__(normalizeModuleId(id))
+    return (globalThis as any).__WAKU_CLIENT_IMPORT__(normalizeModuleId(id));
   });
 
   const { INTERNAL_ServerRoot } =

--- a/packages/waku/src/lib/renderers/rsc.ts
+++ b/packages/waku/src/lib/renderers/rsc.ts
@@ -37,8 +37,8 @@ export async function renderRsc(
   const resolveClientEntry = ctx.unstable_devServer
     ? ctx.unstable_devServer.resolveClientEntry
     : resolveClientEntryForPrd;
-  // @ts-ignore
-  const clientBundlerConfig = new Proxy(
+  // @ts-expect-error might not need this
+  const _clientBundlerConfig = new Proxy(
     {},
     {
       get(_target, encodedId: string) {
@@ -49,19 +49,21 @@ export async function renderRsc(
       },
     },
   );
-  return renderToReadableStream(elements,
+  return renderToReadableStream(
+    elements,
     // clientBundlerConfig,
     {
-    onError: (err: unknown) => {
-      console.log(err);
-      onError.forEach((fn) => fn(err, ctx as HandlerContext, 'rsc'));
-      if (typeof (err as any)?.digest === 'string') {
-        // This is not correct according to the type though.
-        return (err as { digest: string }).digest;
-      }
+      onError: (err: unknown) => {
+        console.log(err);
+        onError.forEach((fn) => fn(err, ctx as HandlerContext, 'rsc'));
+        if (typeof (err as any)?.digest === 'string') {
+          // This is not correct according to the type though.
+          return (err as { digest: string }).digest;
+        }
+      },
+      temporaryReferences: temporaryReferencesMap.get(ctx),
     },
-    temporaryReferences: temporaryReferencesMap.get(ctx),
-  });
+  );
 }
 
 export function renderRscElement(
@@ -80,8 +82,8 @@ export function renderRscElement(
   const resolveClientEntry = ctx.unstable_devServer
     ? ctx.unstable_devServer.resolveClientEntry
     : resolveClientEntryForPrd;
-  // @ts-ignore
-  const clientBundlerConfig = new Proxy(
+  // @ts-expect-error might not need this
+  const _clientBundlerConfig = new Proxy(
     {},
     {
       get(_target, encodedId: string) {
@@ -91,18 +93,20 @@ export function renderRscElement(
       },
     },
   );
-  return renderToReadableStream(element,
+  return renderToReadableStream(
+    element,
     // clientBundlerConfig,
     {
-    onError: (err: unknown) => {
-      onError.forEach((fn) => fn(err, ctx as HandlerContext, 'rsc'));
-      if (typeof (err as any)?.digest === 'string') {
-        // This is not correct according to the type though.
-        return (err as { digest: string }).digest;
-      }
+      onError: (err: unknown) => {
+        onError.forEach((fn) => fn(err, ctx as HandlerContext, 'rsc'));
+        if (typeof (err as any)?.digest === 'string') {
+          // This is not correct according to the type though.
+          return (err as { digest: string }).digest;
+        }
+      },
+      temporaryReferences: temporaryReferencesMap.get(ctx),
     },
-    temporaryReferences: temporaryReferencesMap.get(ctx),
-  });
+  );
 }
 
 export async function collectClientModules(
@@ -114,8 +118,8 @@ export async function collectClientModules(
     default: { renderToReadableStream },
   } = rsdwServer;
   const idSet = new Set<string>();
-  // @ts-ignore
-  const clientBundlerConfig = new Proxy(
+  // @ts-expect-error might not need this
+  const _clientBundlerConfig = new Proxy(
     {},
     {
       get(_target, encodedId: string) {
@@ -126,7 +130,8 @@ export async function collectClientModules(
       },
     },
   );
-  const readable = renderToReadableStream(elements,
+  const readable = renderToReadableStream(
+    elements,
     // clientBundlerConfig
   );
   await new Promise<void>((resolve, reject) => {
@@ -154,8 +159,8 @@ export async function decodeBody(
   const {
     default: { decodeReply, createTemporaryReferenceSet },
   } = modules.rsdwServer as { default: typeof RSDWServerType };
-  // @ts-ignore
-  const serverBundlerConfig = new Proxy(
+  // @ts-expect-error might not need this
+  const _serverBundlerConfig = new Proxy(
     {},
     {
       get(_target, encodedId: string) {
@@ -177,18 +182,22 @@ export async function decodeBody(
     ) {
       // XXX This doesn't support streaming unlike busboy
       const formData = await parseFormData(bodyBuf, contentType);
-      decodedBody = await decodeReply(formData,
+      decodedBody = await decodeReply(
+        formData,
         // serverBundlerConfig,
         {
-        temporaryReferences,
-      });
+          temporaryReferences,
+        },
+      );
     } else if (bodyBuf.byteLength > 0) {
       const bodyStr = bufferToString(bodyBuf);
-      decodedBody = await decodeReply(bodyStr,
+      decodedBody = await decodeReply(
+        bodyStr,
         // serverBundlerConfig,
         {
-        temporaryReferences,
-      });
+          temporaryReferences,
+        },
+      );
     }
   }
   return decodedBody;
@@ -249,8 +258,8 @@ export async function decodePostAction(
         // Assuming this is probably for api
         return null;
       }
-      // @ts-ignore
-      const serverBundlerConfig = new Proxy(
+      // @ts-expect-error might not need this
+      const _serverBundlerConfig = new Proxy(
         {},
         {
           get(_target, encodedId: string) {
@@ -261,11 +270,14 @@ export async function decodePostAction(
         },
       );
       setExtractFormState(ctx, (actionResult) =>
-        decodeFormState(actionResult, formData,
+        decodeFormState(
+          actionResult,
+          formData,
           // serverBundlerConfig
         ),
       );
-      return decodeAction(formData,
+      return decodeAction(
+        formData,
         // serverBundlerConfig
       );
     }

--- a/packages/waku/src/minimal/client.ts
+++ b/packages/waku/src/minimal/client.ts
@@ -28,8 +28,8 @@ const { createFromFetch, encodeReply, createTemporaryReferenceSet } =
   } else {
     id = '/' + id + '.js';
   }
-  return (globalThis as any).__WAKU_CLIENT_IMPORT__(id)
-})
+  return (globalThis as any).__WAKU_CLIENT_IMPORT__(id);
+});
 
 declare global {
   interface ImportMeta {


### PR DESCRIPTION
Thank you SO MUCH for pushing forward with Vite and RSC and including Waku in your testing.

I ran 
```sh
pnpm exec prettier -c --write .
```

And made a few edits to the ignores/unused variable warnings.

This gets the prettier, eslint and tsc parts of `pnpm run test` to pass.

Feel free to close / ignore. Just thought I'd share with you in case it's helpful at all. 😄 