### PR TITLE
chore: move code to `waku/vite-rs`

### DIFF
--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -19,4 +19,4 @@ jobs:
       - run: pnpm run compile
       - name: pkg-pr-new
         run: |
-          npx pkg-pr-new publish --comment=off packages/waku-vite-rsc
+          npx pkg-pr-new publish --comment=off packages/waku packages/waku-vite-rsc

--- a/packages/waku/package.json
+++ b/packages/waku/package.json
@@ -65,7 +65,8 @@
     "./router/server": {
       "types": "./dist/router/server.d.ts",
       "default": "./dist/router/server.js"
-    }
+    },
+    "./vite-rsc/*": "./dist/vite-rsc/*.js"
   },
   "bin": {
     "waku": "./cli.js"
@@ -86,6 +87,7 @@
     "node": "^24.0.0 || ^22.7.0 || ^20.8.0"
   },
   "dependencies": {
+    "@hiogawa/vite-rsc": "https://pkg.pr.new/hi-ogawa/vite-plugins/@hiogawa/vite-rsc@3a08bc9",
     "@hono/node-server": "1.14.3",
     "@swc/core": "1.11.31",
     "@vitejs/plugin-react": "4.5.1",
@@ -94,6 +96,7 @@
     "html-react-parser": "5.2.5",
     "rollup": "4.41.1",
     "rsc-html-stream": "0.0.6",
+    "tinyglobby": "^0.2.14",
     "vite": "6.3.5"
   },
   "devDependencies": {

--- a/packages/waku/src/cli.ts
+++ b/packages/waku/src/cli.ts
@@ -55,6 +55,9 @@ const { values, positionals } = parseArgs({
     'experimental-compress': {
       type: 'boolean',
     },
+    'experimental-vite-rsc': {
+      type: 'boolean',
+    },
     port: {
       type: 'string',
       short: 'p',
@@ -77,6 +80,13 @@ if (values.version) {
   console.log(version);
 } else if (values.help) {
   displayUsage();
+} else if (
+  values['experimental-vite-rsc'] &&
+  cmd &&
+  ['dev', 'build', 'start'].includes(cmd)
+) {
+  const { main } = await import('./vite-rsc/main.js');
+  await main({ cmd, port: parseInt(values.port || '3000', 10) });
 } else {
   switch (cmd) {
     case 'dev':

--- a/packages/waku/src/vite-rsc/entry.browser.pre.tsx
+++ b/packages/waku/src/vite-rsc/entry.browser.pre.tsx
@@ -1,0 +1,17 @@
+import * as ReactClient from '@hiogawa/vite-rsc/browser';
+import { unstable_callServerRsc } from 'waku/minimal/client';
+ReactClient.setServerCallback(unstable_callServerRsc);
+
+if (import.meta.hot) {
+  import.meta.hot.on('rsc:update', (e) => {
+    console.log('[rsc:update]', e);
+    if (import.meta.env.WAKU_SERVER_HMR === 'reload') {
+      window.location.reload();
+    }
+    if (import.meta.env.WAKU_SERVER_HMR === true) {
+      (globalThis as any).__WAKU_RSC_RELOAD_LISTENERS__?.forEach((l: any) =>
+        l(),
+      );
+    }
+  });
+}

--- a/packages/waku/src/vite-rsc/entry.browser.tsx
+++ b/packages/waku/src/vite-rsc/entry.browser.tsx
@@ -1,0 +1,3 @@
+import './entry.browser.pre';
+// eslint-disable-next-line
+import 'virtual:vite-rsc-waku/client-entry';

--- a/packages/waku/src/vite-rsc/entry.rsc.tsx
+++ b/packages/waku/src/vite-rsc/entry.rsc.tsx
@@ -1,0 +1,214 @@
+import * as ReactServer from '@hiogawa/vite-rsc/rsc';
+import type React from 'react';
+import type { unstable_defineEntries } from 'waku/minimal/server';
+
+export type RscElementsPayload = Record<string, unknown>;
+// eslint-disable-next-line
+export type RscHtmlPayload = React.ReactNode;
+
+type WakuServerEntry = ReturnType<typeof unstable_defineEntries>;
+type HandleRequestInput = Parameters<WakuServerEntry['handleRequest']>[0];
+type HandleRequestImplementation = Parameters<
+  WakuServerEntry['handleRequest']
+>[1];
+
+type HandleReq = {
+  body: ReadableStream | null;
+  url: URL;
+  method: string;
+  headers: Readonly<Record<string, string>>;
+};
+
+type HandlerRes = {
+  body?: ReadableStream;
+  headers?: Record<string, string | string[]>;
+  status?: number;
+};
+
+// cf. packages/waku/src/lib/middleware/handler.ts `handler`
+export default async function handler(request: Request): Promise<Response> {
+  // eslint-disable-next-line
+  await import('virtual:vite-rsc-waku/set-platform-data');
+
+  // eslint-disable-next-line
+  const wakuServerEntry = (await import('virtual:vite-rsc-waku/server-entry'))
+    .default;
+
+  const url = new URL(request.url);
+  const req: HandleReq = {
+    body: request.body,
+    url,
+    method: request.method,
+    headers: Object.fromEntries(request.headers.entries()),
+  };
+
+  // cf. packages/waku/src/lib/middleware/handler.ts `getInput`
+  const rscPathPrefix =
+    import.meta.env.WAKU_CONFIG_BASE_PATH +
+    import.meta.env.WAKU_CONFIG_RSC_BASE +
+    '/';
+  let rscPath: string | undefined;
+  let temporaryReferences: unknown | undefined;
+  let wakuInput: HandleRequestInput;
+  if (url.pathname.startsWith(rscPathPrefix)) {
+    rscPath = decodeRscPath(
+      decodeURI(url.pathname.slice(rscPathPrefix.length)),
+    );
+    // server action: js
+    const actionId = decodeFuncId(rscPath);
+    if (actionId) {
+      const contentType = request.headers.get('content-type');
+      const body = contentType?.startsWith('multipart/form-data')
+        ? await request.formData()
+        : await request.text();
+      temporaryReferences = ReactServer.createTemporaryReferenceSet();
+      const args = await ReactServer.decodeReply(body, { temporaryReferences });
+      const action = await ReactServer.loadServerAction(actionId);
+      wakuInput = {
+        type: 'function',
+        fn: action as any,
+        args,
+        req,
+      };
+    } else {
+      // client RSC request
+      wakuInput = {
+        type: 'component',
+        rscPath,
+        rscParams: url.searchParams,
+        req,
+      };
+    }
+  } else if (request.method === 'POST') {
+    // cf. packages/waku/src/lib/renderers/rsc.ts `decodePostAction`
+    const contentType = request.headers.get('content-type');
+    if (
+      typeof contentType === 'string' &&
+      contentType.startsWith('multipart/form-data')
+    ) {
+      // server action: no js (progressive enhancement)
+      const formData = await request.formData();
+      const decodedAction = await ReactServer.decodeAction(formData);
+      wakuInput = {
+        type: 'action',
+        fn: async () => {
+          const result = await decodedAction();
+          return await ReactServer.decodeFormState(result, formData);
+        },
+        pathname: url.pathname,
+        req,
+      };
+    } else {
+      // POST API request
+      wakuInput = {
+        type: 'custom',
+        pathname: url.pathname,
+        req,
+      };
+    }
+  } else {
+    // SSR
+    wakuInput = {
+      type: 'custom',
+      pathname: url.pathname,
+      req,
+    };
+  }
+
+  const implementation: HandleRequestImplementation = {
+    // TODO: what `options` for?
+    async renderRsc(elements, _options) {
+      return ReactServer.renderToReadableStream<RscElementsPayload>(elements, {
+        temporaryReferences,
+      });
+    },
+    async renderHtml(
+      elements,
+      html,
+      options?: { rscPath?: string; actionResult?: any },
+    ) {
+      const ssrEntryModule = await import.meta.viteRsc.loadModule<
+        typeof import('./entry.ssr.tsx')
+      >('ssr', 'index');
+
+      const rscElementsStream =
+        ReactServer.renderToReadableStream<RscElementsPayload>(elements);
+
+      const rscHtmlStream =
+        ReactServer.renderToReadableStream<RscHtmlPayload>(html);
+
+      const htmlStream = await ssrEntryModule.renderHTML(
+        rscElementsStream,
+        rscHtmlStream,
+        {
+          debugNojs: url.searchParams.has('__nojs'),
+          formState: options?.actionResult,
+          rscPath: options?.rscPath,
+        },
+      );
+      return {
+        body: htmlStream as any,
+        headers: { 'content-type': 'text/html' },
+      };
+    },
+  };
+
+  const wakuResult = await wakuServerEntry.handleRequest(
+    wakuInput,
+    implementation,
+  );
+
+  const handleRes: HandlerRes = {};
+  if (wakuResult instanceof ReadableStream) {
+    handleRes.body = wakuResult;
+  } else if (wakuResult) {
+    if (wakuResult.body) {
+      handleRes.body = wakuResult.body;
+    }
+    if (wakuResult.status) {
+      handleRes.status = wakuResult.status;
+    }
+    if (wakuResult.headers) {
+      Object.assign((handleRes.headers ||= {}), wakuResult.headers);
+    }
+  }
+  if (handleRes.body || handleRes.status) {
+    return new Response(handleRes.body || '', {
+      status: handleRes.status || 200,
+      headers: handleRes.headers as any,
+    });
+  }
+  return new Response('[vite-rsc] not found', { status: 404 });
+}
+
+// cf. packages/waku/src/lib/renderers/utils.ts
+const decodeRscPath = (rscPath: string) => {
+  if (!rscPath.endsWith('.txt')) {
+    const err = new Error('Invalid encoded rscPath');
+    (err as any).statusCode = 400;
+    throw err;
+  }
+  rscPath = rscPath.slice(0, -'.txt'.length);
+  if (rscPath.startsWith('_')) {
+    rscPath = rscPath.slice(1);
+  }
+  if (rscPath.endsWith('_')) {
+    rscPath = rscPath.slice(0, -1);
+  }
+  return rscPath;
+};
+
+const FUNC_PREFIX = 'F/';
+
+const decodeFuncId = (encoded: string) => {
+  if (!encoded.startsWith(FUNC_PREFIX)) {
+    return null;
+  }
+  const index = encoded.lastIndexOf('/');
+  const file = encoded.slice(FUNC_PREFIX.length, index);
+  const name = encoded.slice(index + 1);
+  if (file.startsWith('_')) {
+    return file.slice(1) + '#' + name;
+  }
+  return file + '#' + name;
+};

--- a/packages/waku/src/vite-rsc/entry.ssr.tsx
+++ b/packages/waku/src/vite-rsc/entry.ssr.tsx
@@ -1,0 +1,89 @@
+import { injectRscStreamToHtml } from '@hiogawa/vite-rsc/rsc-html-stream/ssr';
+import * as ReactClient from '@hiogawa/vite-rsc/ssr';
+import React from 'react';
+import type { ReactFormState } from 'react-dom/client';
+import * as ReactDOMServer from 'react-dom/server.edge';
+import { INTERNAL_ServerRoot } from 'waku/minimal/client';
+import type { RscElementsPayload, RscHtmlPayload } from './entry.rsc.js';
+
+export async function renderHTML(
+  rscStream: ReadableStream<Uint8Array>,
+  rscHtmlStream: ReadableStream<Uint8Array>,
+  options?: {
+    rscPath?: string | undefined;
+    formState?: ReactFormState | undefined;
+    nonce?: string | undefined;
+    debugNojs?: boolean | undefined;
+  },
+): Promise<ReadableStream<Uint8Array>> {
+  // cf. packages/waku/src/lib/renderers/html.ts `renderHtml`
+
+  const [stream1, stream2] = rscStream.tee();
+
+  let elementsPromise: Promise<RscElementsPayload>;
+  let htmlPromise: Promise<RscHtmlPayload>;
+
+  // deserialize RSC stream back to React VDOM
+  function SsrRoot() {
+    elementsPromise ??=
+      ReactClient.createFromReadableStream<RscElementsPayload>(stream1);
+    htmlPromise ??=
+      ReactClient.createFromReadableStream<RscHtmlPayload>(rscHtmlStream);
+    return (
+      <INTERNAL_ServerRoot elementsPromise={elementsPromise}>
+        {React.use(htmlPromise)}
+      </INTERNAL_ServerRoot>
+    );
+  }
+
+  // render html (traditional SSR)
+  const bootstrapScriptContent =
+    await import.meta.viteRsc.loadBootstrapScriptContent('index');
+  const htmlStream = await ReactDOMServer.renderToReadableStream(<SsrRoot />, {
+    bootstrapScriptContent: options?.debugNojs
+      ? undefined
+      : getBootstrapPreamble({ rscPathForFakeFetch: options?.rscPath || '' }) +
+        bootstrapScriptContent,
+    nonce: options?.nonce,
+    // no types
+    ...{ formState: options?.formState },
+  } as any);
+
+  let responseStream: ReadableStream<Uint8Array> = htmlStream;
+  if (!options?.debugNojs) {
+    responseStream = responseStream.pipeThrough(
+      injectRscStreamToHtml(stream2, {
+        nonce: options?.nonce,
+      } as any),
+    );
+  }
+
+  return responseStream;
+}
+
+// cf. packages/waku/src/lib/renderers/html.ts `parseHtmlHead`
+function getBootstrapPreamble(options: { rscPathForFakeFetch: string }) {
+  return `
+    globalThis.__WAKU_HYDRATE__ = true;
+    globalThis.__WAKU_PREFETCHED__ = {
+      ${JSON.stringify(options.rscPathForFakeFetch)}: ${FAKE_FETCH_CODE}
+    };
+  `;
+}
+
+const FAKE_FETCH_CODE = `
+Promise.resolve(new Response(new ReadableStream({
+  start(c) {
+    const d = (self.__FLIGHT_DATA ||= []);
+    const t = new TextEncoder();
+    const f = (s) => c.enqueue(typeof s === 'string' ? t.encode(s) : s);
+    d.forEach(f);
+    d.push = f;
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', () => c.close());
+    } else {
+      c.close();
+    }
+  }
+})))
+`;

--- a/packages/waku/src/vite-rsc/main.ts
+++ b/packages/waku/src/vite-rsc/main.ts
@@ -1,0 +1,59 @@
+import { spawn } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import process from 'node:process';
+
+const require = createRequire(import.meta.url);
+
+export async function main(options: { cmd: string; port: number }) {
+  let configFile: string | undefined;
+
+  if (fs.existsSync('waku-vite-rsc.config.ts')) {
+    // allow a dedicated config file for Vite RSC port
+    configFile = 'waku-vite-rsc.config.ts';
+  } else if (!fs.existsSync('vite.config.ts')) {
+    // auto setup vite.config.ts in a hidden place
+    const configCode = `\
+import waku from "waku/vite-rsc/plugin";
+
+export default {
+  plugins: [waku()],
+};
+`;
+    configFile = `node_modules/.cache/waku-vite-rsc/vite.config.${hashString(configCode)}.ts`;
+    if (!fs.existsSync(configFile)) {
+      fs.mkdirSync(path.dirname(configFile), { recursive: true });
+      fs.writeFileSync(configFile, configCode);
+    }
+  }
+
+  // spawn vite
+  const viteBin = path.join(
+    require.resolve('vite/package.json'),
+    '../bin/vite.js',
+  );
+  const proc = spawn(
+    'node',
+    [
+      viteBin,
+      options.cmd === 'start' ? 'preview' : options.cmd,
+      ...(options.cmd !== 'build' && options.port
+        ? ['--port', String(options.port)]
+        : []),
+      ...(configFile ? ['-c', configFile] : []),
+    ],
+    {
+      shell: false,
+      stdio: 'inherit',
+    },
+  );
+  proc.on('close', (code) => {
+    process.exitCode = code ?? 1;
+  });
+}
+
+function hashString(v: string) {
+  return createHash('sha256').update(v).digest().toString('hex').slice(0, 10);
+}

--- a/packages/waku/src/vite-rsc/plugin.ts
+++ b/packages/waku/src/vite-rsc/plugin.ts
@@ -1,0 +1,296 @@
+import {
+  normalizePath,
+  type EnvironmentOptions,
+  type PluginOption,
+} from 'vite';
+import react from '@vitejs/plugin-react';
+import rsc from '@hiogawa/vite-rsc/plugin';
+import { pathToFileURL } from 'node:url';
+import path from 'node:path';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const PKG_NAME = 'waku';
+
+export default function wakuViteRscPlugin(wakuOptions?: {
+  serverHmr?: boolean | 'reload';
+}): PluginOption {
+  return [
+    react(),
+    rsc(),
+    {
+      name: 'rsc:waku',
+      config() {
+        const toEnvironmentOption = (entry: string) =>
+          ({
+            build: {
+              rollupOptions: {
+                input: {
+                  index: `${PKG_NAME}/vite-rsc/${entry}`,
+                },
+              },
+            },
+          }) satisfies EnvironmentOptions;
+
+        return {
+          define: {
+            'import.meta.env.WAKU_CONFIG_BASE_PATH': JSON.stringify('/'),
+            'import.meta.env.WAKU_CONFIG_RSC_BASE': JSON.stringify('RSC'),
+            // TODO: it fails on router examples, so for now force reload by default
+            'import.meta.env.WAKU_SERVER_HMR': JSON.stringify(
+              wakuOptions?.serverHmr ?? 'reload',
+            ),
+          },
+          environments: {
+            client: toEnvironmentOption('entry.browser'),
+            ssr: toEnvironmentOption('entry.ssr'),
+            rsc: toEnvironmentOption('entry.rsc'),
+          },
+        };
+      },
+      configEnvironment(name, config, _env) {
+        // make @hiogawa/vite-rsc usable as a transitive dependency
+        // https://github.com/hi-ogawa/vite-plugins/issues/968
+        if (config.optimizeDeps?.include) {
+          config.optimizeDeps.include = config.optimizeDeps.include.map(
+            (name) => {
+              if (name.startsWith('@hiogawa/vite-rsc/')) {
+                name = `${PKG_NAME} > ${name}`;
+              }
+              return name;
+            },
+          );
+        }
+
+        return {
+          resolve: {
+            noExternal: [PKG_NAME],
+          },
+          optimizeDeps: {
+            exclude: [PKG_NAME, 'waku/minimal/client', 'waku/router/client'],
+          },
+          build: {
+            // top-level-await in packages/waku/src/lib/middleware/context.ts
+            target:
+              config.build?.target ??
+              (name !== 'client' ? 'esnext' : undefined),
+          },
+        };
+      },
+    },
+    {
+      // don't violate https://github.com/hi-ogawa/rsc-tests
+      name: 'rsc:waku:fix-internal-client-boundary',
+      transform(code, id) {
+        if (id.includes('/node_modules/waku/dist/router/create-pages.js')) {
+          return code
+            .replaceAll(
+              `from '../minimal/client.js'`,
+              `from 'waku/minimal/client'`,
+            )
+            .replaceAll(
+              `from '../router/client.js'`,
+              `from 'waku/router/client'`,
+            );
+        }
+        if (id.includes('/node_modules/waku/dist/router/define-router.js')) {
+          return code.replaceAll(
+            `from './client.js'`,
+            `from 'waku/router/client'`,
+          );
+        }
+      },
+    },
+    {
+      name: 'rsc:waku:user-entries',
+      // resolve user entries or fallbacks to "managed mode"
+      async resolveId(source, _importer, options) {
+        if (source === 'virtual:vite-rsc-waku/server-entry') {
+          const resolved = await this.resolve(
+            '/src/server-entry',
+            undefined,
+            options,
+          );
+          return resolved ? resolved : '\0' + source;
+        }
+        if (source === 'virtual:vite-rsc-waku/client-entry') {
+          const resolved = await this.resolve(
+            '/src/client-entry',
+            undefined,
+            options,
+          );
+          return resolved ? resolved : '\0' + source;
+        }
+      },
+      load(id) {
+        // cf. packages/waku/src/lib/plugins/vite-plugin-rsc-managed.ts
+        if (id === '\0virtual:vite-rsc-waku/server-entry') {
+          return getManagedEntries(
+            path.join(this.environment.config.root, 'src/server-entry.js'),
+            'src',
+            {
+              pagesDir: 'pages',
+              apiDir: 'api',
+            },
+          );
+        }
+        if (id === '\0virtual:vite-rsc-waku/client-entry') {
+          return getManagedMain();
+        }
+      },
+    },
+    {
+      // rewrite `react-server-dom-webpack` in `waku/minimal/client`
+      name: 'rsc:waku:patch-webpack',
+      enforce: 'pre',
+      resolveId(source, _importer, _options) {
+        if (source === 'react-server-dom-webpack/client') {
+          return '\0' + source;
+        }
+      },
+      load(id) {
+        if (id === '\0react-server-dom-webpack/client') {
+          if (this.environment.name === 'client') {
+            return `
+              import * as ReactClient from ${JSON.stringify(import.meta.resolve('@hiogawa/vite-rsc/browser'))};
+              export default ReactClient;
+            `;
+          }
+          return `export default {}`;
+        }
+      },
+    },
+    {
+      // cf. packages/waku/src/lib/plugins/vite-plugin-rsc-hmr.ts
+      name: 'rsc:waku:patch-server-hmr',
+      apply: 'serve',
+      async transform(code, id) {
+        if (wakuOptions?.serverHmr !== true) {
+          return;
+        }
+        if (this.environment.name !== 'client') {
+          return;
+        }
+        if (id.includes('/waku/dist/minimal/client.js')) {
+          return code.replace(
+            /\nexport const fetchRsc = \(.*?\)=>\{/,
+            (m) =>
+              m +
+              `
+{
+  const refetchRsc = () => {
+    delete fetchCache[ENTRY];
+    const data = fetchRsc(rscPath, rscParams, fetchCache);
+    fetchCache[SET_ELEMENTS](() => data);
+  };
+  globalThis.__WAKU_RSC_RELOAD_LISTENERS__ ||= [];
+  const index = globalThis.__WAKU_RSC_RELOAD_LISTENERS__.indexOf(globalThis.__WAKU_REFETCH_RSC__);
+  if (index !== -1) {
+    globalThis.__WAKU_RSC_RELOAD_LISTENERS__.splice(index, 1, refetchRsc);
+  } else {
+    globalThis.__WAKU_RSC_RELOAD_LISTENERS__.push(refetchRsc);
+  }
+  globalThis.__WAKU_REFETCH_RSC__ = refetchRsc;
+}
+`,
+          );
+        }
+      },
+    },
+    {
+      // expose `__WAKU_SERVER_PLATFORM_DATA__.fsRouterFiles` for build.
+      // for now we manually crawl `src/pages/` to collect all files.
+      // TODO: support `handleBuild` API.
+      name: 'rsc:waku:set-platform-data',
+      resolveId(source) {
+        if (source === 'virtual:vite-rsc-waku/set-platform-data') {
+          assert.equal(this.environment.name, 'rsc');
+          if (this.environment.mode === 'build') {
+            return { id: source, external: true, moduleSideEffects: true };
+          }
+          return '\0' + source;
+        }
+      },
+      async load(id) {
+        if (id === '\0virtual:vite-rsc-waku/set-platform-data') {
+          // no-op during dev
+          assert.equal(this.environment.mode, 'dev');
+          return `export {}`;
+        }
+      },
+      renderChunk(code, chunk) {
+        if (code.includes(`virtual:vite-rsc-waku/set-platform-data`)) {
+          const replacement = normalizeRelativePath(
+            path.relative(
+              path.join(chunk.fileName, '..'),
+              '__waku_set_platform_data.js',
+            ),
+          );
+          return code.replaceAll(
+            'virtual:vite-rsc-waku/set-platform-data',
+            () => replacement,
+          );
+        }
+      },
+      writeBundle: {
+        order: 'post',
+        async handler(_options, _bundle) {
+          if (this.environment.name !== 'ssr') {
+            return;
+          }
+          const { glob } = await import('tinyglobby');
+          const fsRouterFiles = await glob(`**/*.{ts,tsx,js,jsx,mjs,cjs}`, {
+            cwd: `src/pages/`,
+          });
+          const setPlatformDataCode = `\
+            globalThis.__WAKU_SERVER_PLATFORM_DATA__ ??= {};
+            __WAKU_SERVER_PLATFORM_DATA__.fsRouterFiles = [${JSON.stringify(fsRouterFiles)}];
+          `;
+          const setPlatformDataFile = path.join(
+            this.environment.getTopLevelConfig().environments.rsc!.build.outDir,
+            '__waku_set_platform_data.js',
+          );
+          fs.writeFileSync(setPlatformDataFile, setPlatformDataCode);
+        },
+      },
+    },
+  ];
+}
+
+// cf. packages/waku/src/lib/plugins/vite-plugin-rsc-managed.ts
+const EXTENSIONS = ['.js', '.ts', '.tsx', '.jsx', '.mjs', '.cjs'];
+
+const getManagedEntries = (
+  filePath: string,
+  srcDir: string,
+  options: { pagesDir: string; apiDir: string },
+) => `
+import { unstable_fsRouter as fsRouter } from 'waku/router/server';
+
+export default fsRouter(
+  '${pathToFileURL(filePath)}',
+  (file) => import.meta.glob('/${srcDir}/pages/**/*.{${EXTENSIONS.map((ext) =>
+    ext.replace(/^\./, ''),
+  ).join(',')}}')[\`/${srcDir}/pages/\${file}\`]?.(),
+  { pagesDir: '${options.pagesDir}', apiDir: '${options.apiDir}' },
+);
+`;
+
+const getManagedMain = () => `
+import { StrictMode, createElement } from 'react';
+import { createRoot, hydrateRoot } from 'react-dom/client';
+import { Router } from 'waku/router/client';
+
+const rootElement = createElement(StrictMode, null, createElement(Router));
+
+if (globalThis.__WAKU_HYDRATE__) {
+  hydrateRoot(document, rootElement);
+} else {
+  createRoot(document).render(rootElement);
+}
+`;
+
+function normalizeRelativePath(s: string) {
+  s = normalizePath(s);
+  return s[0] === '.' ? s : './' + s;
+}

--- a/packages/waku/src/vite-rsc/types.d.ts
+++ b/packages/waku/src/vite-rsc/types.d.ts
@@ -1,0 +1,16 @@
+/// <reference types="vite/client" />
+/// <reference types="@hiogawa/vite-rsc/types" />
+
+declare module 'virtual:vite-rsc-waku/server-entry' {
+  import type { unstable_defineEntries } from 'waku/minimal/server';
+  const default_: ReturnType<typeof unstable_defineEntries>;
+  export default default_;
+}
+
+declare module 'virtual:vite-rsc-waku/client-entry' {}
+
+declare module 'react-dom/server.edge' {
+  export * from 'react-dom/server';
+}
+
+declare module 'virtual:vite-rsc-waku/set-platform-data' {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1494,6 +1494,9 @@ importers:
 
   packages/waku:
     dependencies:
+      '@hiogawa/vite-rsc':
+        specifier: https://pkg.pr.new/hi-ogawa/vite-plugins/@hiogawa/vite-rsc@3a08bc9
+        version: https://pkg.pr.new/hi-ogawa/vite-plugins/@hiogawa/vite-rsc@3a08bc9(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vite@6.3.5(@types/node@22.15.29)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.41.0)(tsx@4.19.4)(yaml@2.8.0))
       '@hono/node-server':
         specifier: 1.14.3
         version: 1.14.3(hono@4.7.11)
@@ -1518,6 +1521,9 @@ importers:
       rsc-html-stream:
         specifier: 0.0.6
         version: 0.0.6
+      tinyglobby:
+        specifier: ^0.2.14
+        version: 0.2.14
       vite:
         specifier: 6.3.5
         version: 6.3.5(@types/node@22.15.29)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.41.0)(tsx@4.19.4)(yaml@2.8.0)
@@ -2594,9 +2600,21 @@ packages:
   '@fastify/busboy@3.1.1':
     resolution: {integrity: sha512-5DGmA8FTdB2XbDeEwc/5ZXBl6UbBAyBOOLlPuBnZ/N1SwdH9Ii+cOX3tBROlDgcTXxjOYnLMVoKk9+FXAw0CJw==}
 
+  '@hiogawa/transforms@https://pkg.pr.new/hi-ogawa/vite-plugins/@hiogawa/transforms@3a08bc92783f337f634a0fe9688d9700911cf9f9':
+    resolution: {tarball: https://pkg.pr.new/hi-ogawa/vite-plugins/@hiogawa/transforms@3a08bc92783f337f634a0fe9688d9700911cf9f9}
+    version: 0.1.4
+
   '@hiogawa/transforms@https://pkg.pr.new/hi-ogawa/vite-plugins/@hiogawa/transforms@f9e7e2d0aea428c7ba4594ec7c17b9fa08f76437':
     resolution: {tarball: https://pkg.pr.new/hi-ogawa/vite-plugins/@hiogawa/transforms@f9e7e2d0aea428c7ba4594ec7c17b9fa08f76437}
     version: 0.1.4
+
+  '@hiogawa/vite-rsc@https://pkg.pr.new/hi-ogawa/vite-plugins/@hiogawa/vite-rsc@3a08bc9':
+    resolution: {tarball: https://pkg.pr.new/hi-ogawa/vite-plugins/@hiogawa/vite-rsc@3a08bc9}
+    version: 0.4.5
+    peerDependencies:
+      react: '*'
+      react-dom: '*'
+      vite: '*'
 
   '@hiogawa/vite-rsc@https://pkg.pr.new/hi-ogawa/vite-plugins/@hiogawa/vite-rsc@f9e7e2d':
     resolution: {tarball: https://pkg.pr.new/hi-ogawa/vite-plugins/@hiogawa/vite-rsc@f9e7e2d}
@@ -8531,11 +8549,29 @@ snapshots:
 
   '@fastify/busboy@3.1.1': {}
 
+  '@hiogawa/transforms@https://pkg.pr.new/hi-ogawa/vite-plugins/@hiogawa/transforms@3a08bc92783f337f634a0fe9688d9700911cf9f9':
+    dependencies:
+      estree-walker: 3.0.3
+      magic-string: 0.30.17
+      periscopic: 4.0.2
+
   '@hiogawa/transforms@https://pkg.pr.new/hi-ogawa/vite-plugins/@hiogawa/transforms@f9e7e2d0aea428c7ba4594ec7c17b9fa08f76437':
     dependencies:
       estree-walker: 3.0.3
       magic-string: 0.30.17
       periscopic: 4.0.2
+
+  '@hiogawa/vite-rsc@https://pkg.pr.new/hi-ogawa/vite-plugins/@hiogawa/vite-rsc@3a08bc9(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vite@6.3.5(@types/node@22.15.29)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.41.0)(tsx@4.19.4)(yaml@2.8.0))':
+    dependencies:
+      '@hiogawa/transforms': https://pkg.pr.new/hi-ogawa/vite-plugins/@hiogawa/transforms@3a08bc92783f337f634a0fe9688d9700911cf9f9
+      '@mjackson/node-fetch-server': 0.6.1
+      es-module-lexer: 1.7.0
+      magic-string: 0.30.17
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      turbo-stream: 3.1.0
+      vite: 6.3.5(@types/node@22.15.29)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.41.0)(tsx@4.19.4)(yaml@2.8.0)
+      vitefu: 1.0.6(vite@6.3.5(@types/node@22.15.29)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.41.0)(tsx@4.19.4)(yaml@2.8.0))
 
   '@hiogawa/vite-rsc@https://pkg.pr.new/hi-ogawa/vite-plugins/@hiogawa/vite-rsc@f9e7e2d(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vite@6.3.5(@types/node@22.15.29)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.41.0)(tsx@4.19.4)(yaml@2.8.0))':
     dependencies:


### PR DESCRIPTION
This allows swapping with vite rsc version by a single flag

```sh
pnpm -C examples/01_template dev --experimental-vite-rsc
pnpm -C examples/01_template build --experimental-vite-rsc
pnpm -C examples/01_template start --experimental-vite-rsc
```